### PR TITLE
Update build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "org.webjars" % "jquery" % "1.11.0",
   "net.codingwell" %% "scala-guice" % "4.0.0-beta4",
   "com.typesafe.play" %% "play-slick" % "0.8.0",
-  "mysql" % "mysql-connector-java" % "5.1.18",
+  "mysql" % "mysql-connector-java" % "5.1.32",
   cache
 )
 


### PR DESCRIPTION
mysql-connector-java 5.1.18 cause exception.

```
play.api.Application$$anon$1: Execution exception[[MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OPTION SQL_SELECT_LIMIT=DEFAULT' at line 1]]

```

And change to the latest version can solve this problem.
